### PR TITLE
Use consistent header levels

### DIFF
--- a/parsl-introduction.ipynb
+++ b/parsl-introduction.ipynb
@@ -32,7 +32,7 @@
     "Parsl's `DataFlowKernel` acts as an abstraction layer over any pool of execution resources (e.g., clusters, clouds, threads). \n",
     "\n",
     "\n",
-    "We'll come back to the DataFlowKernel later in this tutorial. For now, we configure this example to use a pool of [threads](https://en.wikipedia.org/wiki/Thread_(computing). to facilitate local parallel execution. "
+    "We'll come back to the DataFlowKernel later in this tutorial. For now, we configure this example to use a pool of [threads](https://en.wikipedia.org/wiki/Thread_(computing) to facilitate local parallel execution."
    ]
   },
   {
@@ -83,7 +83,7 @@
     "def hello ():\n",
     "    return 'Hello World!'\n",
     "\n",
-    "print (hello().result())"
+    "print(hello().result())"
    ]
   },
   {
@@ -501,7 +501,7 @@
     "\n",
     "Parsl is designed to support arbitrary execution providers (e.g., PCs, clusters, supercomputers) and execution models (e.g., threads, pilot jobs, etc.). That is, Parsl scripts are independent of execution provider or executor. Instead, the configuration used to run the script tells Parsl how to execute apps on the desired environment. Parsl provides a high level abstraction, called a Block, for describing the resource configuration for a particular app or script.\n",
     "\n",
-    "Information about the different execution providers and executors supported is included in the [Parsl documentation](https://parsl.readthedocs.io/en/latest/userguide/execution.html)\n"
+    "Information about the different execution providers and executors supported is included in the [Parsl documentation](https://parsl.readthedocs.io/en/latest/userguide/execution.html).\n"
    ]
   },
   {

--- a/parsl-introduction.ipynb
+++ b/parsl-introduction.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Parsl Tutorial\n",
+    "# Parsl Tutorial\n",
     "\n",
     "Parsl is a native Python library that allows you to write functions that execute in parallel and tie them together with dependencies to create workflows. Parsl wraps Python functions as \"Apps\" using the **@App** decorator. Decorated functions can run in parallel when all their inputs are ready.\n",
     "\n",
@@ -63,12 +63,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# 1. Apps\n",
+    "## 1. Apps\n",
     "\n",
     "\n",
     "In Parsl an `app` is a piece of code that can be asynchronously executed on an execution resource (e.g., cloud, cluster, or local PC). Parsl provides support for pure Python apps and also command-line apps executed via Bash.\n",
     "\n",
-    "## Python Apps\n",
+    "### Python Apps\n",
     "\n",
     "As a first example let's define a simple Python function that returns the string 'Hello World!'. This function is made into a Parsl App using the **@App** decorator. The decorator specifies the type of App ('python'|'bash') and the `DataFlowKernel` object as arguments."
    ]
@@ -183,14 +183,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# 2. Futures\n",
+    "## 2. Futures\n",
     "When a Python function is invoked, the Python interpreter waits for the function to complete execution and returns the results. In case of long running functions it may not be desirable to wait for completion, instead it is often preferable that functions are asynchronous. Parsl provides such asynchronous behavior by returning a future in lieu of results. A future is essentially an object that allows us to track the status of an asynchronous task so that it may, in the future, be interrogated to find the status, results, exceptions, etc.\n",
     "\n",
     "Parsl provides two types of futures: AppFutures and DataFutures. While related, these two types of futures enable subtly different workflow patterns, as we will see.\n",
     "\n",
     "\n",
     "\n",
-    "## AppFutures\n",
+    "### AppFutures\n",
     "AppFutures are the basic building block upon which Parsl scripts are built. Every invocation of a Parsl app returns an AppFuture which may be used to manage execution and control the workflow.\n",
     "\n",
     "Here we show how AppFutures are used to wait for the result of a Python App.\n",
@@ -225,7 +225,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## DataFutures\n",
+    "### DataFutures\n",
     "\n",
     "While AppFutures represent the execution of an asynchronous app, the DataFuture represents the files it produces. Parsl’s dataflow model, in which data flows from one app to another via files, requires such a construct to enable apps to validate creation of required files and to subsequently resolve dependencies when input files are created. When invoking an app, Parsl requires that a list of output files be specified (using the outputs keyword argument). A DataFuture for each file is returned by the app when it is executed. Throughout execution of the app Parsl will monitor these files to 1) ensure they are created, and 2) pass them to any dependent apps."
    ]
@@ -264,11 +264,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# 3. Data Management\n",
+    "## 3. Data Management\n",
     "\n",
     "Parsl is designed to enable implementation of dataflow patterns. These patterns enable workflows to be defined in which the data passed between apps manages the flow of execution. Dataflow programming models are popular as they can cleanly express, via implicit parallelism, the concurrency needed by many applications in a simple and intuitive way.\n",
     "\n",
-    "## Files\n",
+    "### Files\n",
     "\n",
     "Parsl’s file abstraction abstracts local access to a file. It therefore requires only the file path to be defined. Irrespective of where the script, or its apps are executed, Parsl uses this abstraction to access that file. When referencing a Parsl file in an app, Parsl maps the object to the appropriate access path.\n",
     "\n"
@@ -306,12 +306,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# 4.  Composing a workflow\n",
+    "## 4.  Composing a workflow\n",
     "\n",
     "Now that we understand all the building blocks, we can create workflows with Parsl. Unlike other workflow systems, Parsl creates implicit workflows based on the passing of control or data between Apps. The flexibility of this model allows for the creation of a wide range of workflows from sequential through to complex nested, parallel workflows. As we will see below, a range of workflows can be created by passing AppFutures and DataFutures between Apps.\n",
     "\n",
     "\n",
-    "## Sequential workflow\n",
+    "### Sequential workflow\n",
     "\n",
     "Simple sequential or procedural workflows can be created by passing an AppFuture from one task to another. The following example shows one such workflow, which first generates a random number and then writes it to a file. \n"
    ]
@@ -349,7 +349,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Parallel workflow\n",
+    "### Parallel workflow\n",
     "\n",
     "The most common way that Parsl Apps are executed in parallel is via looping. The following example shows how a simple loop can be used to create many random numbers in parallel.\n"
    ]
@@ -382,7 +382,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Parallel dataflow\n",
+    "### Parallel dataflow\n",
     "\n",
     "Parallel dataflows can be developed by passing data between Apps. In this example we create a set of files, each with a random number, we then concatenate these files into a single file and compute the sum of all numbers in that file. In the first two Apps files are exchanged. The final App returns the sum as a Python integer.\n",
     "\n"
@@ -430,7 +430,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Monte Carlo workflow\n",
+    "### Monte Carlo workflow\n",
     "\n",
     "Many scientific applications use the [monte-carlo method](https://en.wikipedia.org/wiki/Monte_Carlo_method#History) to compute results. \n",
     "\n",
@@ -497,7 +497,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Execution and configuration\n",
+    "## Execution and configuration\n",
     "\n",
     "Parsl is designed to support arbitrary execution providers (e.g., PCs, clusters, supercomputers) and execution models (e.g., threads, pilot jobs, etc.). That is, Parsl scripts are independent of execution provider or executor. Instead, the configuration used to run the script tells Parsl how to execute apps on the desired environment. Parsl provides a high level abstraction, called a Block, for describing the resource configuration for a particular app or script.\n",
     "\n",
@@ -508,7 +508,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Local execution with threads\n",
+    "### Local execution with threads\n",
     "\n",
     "As we saw above, we can configure Parsl to execute apps on a local thread pool. This is a good way to parallelize execution on a local PC. The configuration object defines the sites that will be used for execution, optinally the authentication method to be used (e.g., if using SSH), and the execution model to use. In the case of threads we define the maximum number of threads to be used. A number of global configuration options may also be specified.  "
    ]
@@ -539,7 +539,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Local execution with pilot jobs\n",
+    "### Local execution with pilot jobs\n",
     "\n",
     "We can also define a configuration that uses IPythonParallel as the executor. In this mode, pilot jobs are used to manage the submission. Parsl creates an IPythonParallel controller to manage execution and deploys one or more IPythonParallel engines (workers) to execute workload. The following config will instantiate this infrastructure locally, it can be trivially extended to include a remote provider (e.g., Cori, Theta, etc.) for execution. "
    ]
@@ -585,7 +585,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Running a workflow using a configuration\n",
+    "### Running a workflow using a configuration\n",
     "\n",
     "We can now run the same workflow using either of the two configurations defined above. Change which config is used to instantiate the DFK to see the same workflow executed with different models. "
    ]


### PR DESCRIPTION
This is needed so that the readthedocs table of contents does not
get polluted if we automatically convert the notebook to rst. This
is in preparation for a fix for Parsl/parsl#125.