### PR TITLE
fix-checkpointing-example-in-docs-#427

### DIFF
--- a/parsl-advanced-features.ipynb
+++ b/parsl-advanced-features.ipynb
@@ -337,11 +337,10 @@
     "            )\n",
     "        )\n",
     "    ],\n",
-    "    checkpoint_mode='dfk_exit',\n",
-    "    run_dir='/tmp'\n",
+    "    checkpoint_mode='task_exit',\n",
     ")\n",
     "\n",
-    "parsl.load(local_ipp)\n",
+    "dfk = parsl.load(local_ipp)\n",
     "\n",
     "@python_app(cache=True)\n",
     "def slow_double(x):\n",
@@ -389,11 +388,18 @@
     "\n",
     "parsl.clear()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -407,7 +413,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Removed `run_dir=/tmp`, changed `checkpoint_mode="dfk_exit"` to `checkpoint_mode="task_exit"`. If we still want to use `checkpoint_mode="dfk_exit"`, we need `dfk_cleanup()` at the end to shutdown DFK. This fixes Parsl/parsl#427.