### PR TITLE
Fixed Checkpoint Bug

### DIFF
--- a/2-parsl-advanced-features.ipynb
+++ b/2-parsl-advanced-features.ipynb
@@ -387,7 +387,7 @@
     "# set the stream logger to print debug messages\n",
     "#set_stream_logger()\n",
     "\n",
-    "local_htex.checkpoint_files = get_all_checkpoints()\n",
+    "local_ipp.checkpoint_files = get_all_checkpoints()\n",
     "parsl.load(local_ipp)\n",
     "\n",
     "# Rerun the same workflow\n",
@@ -749,9 +749,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
In the Checkpoint Section, when continuing from a checkpoint the checkpoints get added to the `local_htex` config instead of `local_ipp` config. 
This causes the app to run again instead of using the prior results. I fixed that by loading the checkpoints into the right config `local_ipp`
