### PR TITLE
Revert "This is a symlink to temporarily make parsl/stable v1.0.0 docs build"

### DIFF
--- a/parsl-introduction.ipynb
+++ b/parsl-introduction.ipynb
@@ -1,1 +1,0 @@
-1-parsl-introduction.ipynb


### PR DESCRIPTION
Reverts Parsl/parsl-tutorial#29

symlinks don't work correctly over raw.githubusercontent.com.