### PR TITLE
Fixed a bug in the Gantt chart of task execution times

### DIFF
--- a/2-parsl-advanced-features.ipynb
+++ b/2-parsl-advanced-features.ipynb
@@ -737,6 +737,7 @@
     "          'running': 'rgb(0, 0, 255)',\n",
     "          'exec_done': 'rgb(0, 200, 0)',\n",
     "          'done': 'rgb(0, 200, 0)',\n",
+    "          'failed': 'rgb(255, 100, 100)',\n",
     "         }\n",
     "fig = ff.create_gantt(parsl_tasks,\n",
     "                      title=\"\",\n",


### PR DESCRIPTION
Hi,

A big fan of Parsl here. Thanks for creating this package!

Code for generating the Gantt chart of task execution times would bug out if a task failed. This is because there was no color specified for the `failed` status. 

I added `failed` to `colors` and assigned the red color to it.

I hope this helps!